### PR TITLE
Adding descriptions for firewall CRS and operator/parameter objects

### DIFF
--- a/overlay.yaml
+++ b/overlay.yaml
@@ -576,42 +576,149 @@ actions:
     update:
       type: string
       enum: [managedRules.update]
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs
+  # Update CRS object descriptions for /v1/security/firewall/config put responses 200
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs
     update:
       description: Custom Ruleset
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.sd
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.sd
     update:
       description: Scanner Detection - Detect and prevent reconnaissance activities from network scanning tools.
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.ma
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.ma
     update:
       description: Multipart Attack - Block attempts to bypass security controls using multipart/form-data encoding.      
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.lfi
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.lfi
     update:
       description: Local File Inclusion Attack - Prevent unauthorized access to local files through web applications.   
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.rfi
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.rfi
     update:
       description: Remote File Inclusion Attack - Prohibit unauthorized upload or execution of remote files.    
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.rce
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.rce
     update:
       description: Remote Execution Attack - Prevent unauthorized execution of remote scripts or commands.          
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.php
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.php
     update:
       description: PHP Attack - Safeguard against vulnerability exploits in PHP-based applications.
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.gen
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.gen
     update:
       description: Generic Attack - Provide broad protection from various undefined or novel attack vectors.    
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.xss
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.xss
     update:
       description: XSS Attack - Prevent injection of malicious scripts into trusted webpages.  
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.sqli
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.sqli
     update:
       description: SQL Injection Attack - Prohibit unauthorized use of SQL commands to manipulate databases. 
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.sf
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.sf
     update:
       description: Session Fixation Attack - Prevent unauthorized takeover of user sessions by enforcing unique session IDs.    
-  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.java
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.java
     update:
-      description: Java Attack - Mitigate risks of exploitation targeting Java-based applications or components.                                       
+      description: Java Attack - Mitigate risks of exploitation targeting Java-based applications or components.    
+  # Update CRS object descriptions for /v1/security/firewall/config put requestBody    
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs
+    update:
+      description: Custom Ruleset
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.sd
+    update:
+      description: Scanner Detection - Detect and prevent reconnaissance activities from network scanning tools.
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.ma
+    update:
+      description: Multipart Attack - Block attempts to bypass security controls using multipart/form-data encoding.      
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.lfi
+    update:
+      description: Local File Inclusion Attack - Prevent unauthorized access to local files through web applications.   
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.rfi
+    update:
+      description: Remote File Inclusion Attack - Prohibit unauthorized upload or execution of remote files.    
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.rce
+    update:
+      description: Remote Execution Attack - Prevent unauthorized execution of remote scripts or commands.          
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.php
+    update:
+      description: PHP Attack - Safeguard against vulnerability exploits in PHP-based applications.
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.gen
+    update:
+      description: Generic Attack - Provide broad protection from various undefined or novel attack vectors.    
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.xss
+    update:
+      description: XSS Attack - Prevent injection of malicious scripts into trusted webpages.  
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.sqli
+    update:
+      description: SQL Injection Attack - Prohibit unauthorized use of SQL commands to manipulate databases. 
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.sf
+    update:
+      description: Session Fixation Attack - Prevent unauthorized takeover of user sessions by enforcing unique session IDs.    
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.crs.properties.java
+    update:
+      description: Java Attack - Mitigate risks of exploitation targeting Java-based applications or components.  
+  # Update CRS object descriptions for /v1/security/firewall/config/{configVersion} get responses 200    
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs
+    update:
+      description: Custom Ruleset
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.sd
+    update:
+      description: Scanner Detection - Detect and prevent reconnaissance activities from network scanning tools.
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.ma
+    update:
+      description: Multipart Attack - Block attempts to bypass security controls using multipart/form-data encoding.      
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.lfi
+    update:
+      description: Local File Inclusion Attack - Prevent unauthorized access to local files through web applications.   
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.rfi
+    update:
+      description: Remote File Inclusion Attack - Prohibit unauthorized upload or execution of remote files.    
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.rce
+    update:
+      description: Remote Execution Attack - Prevent unauthorized execution of remote scripts or commands.          
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.php
+    update:
+      description: PHP Attack - Safeguard against vulnerability exploits in PHP-based applications.
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.gen
+    update:
+      description: Generic Attack - Provide broad protection from various undefined or novel attack vectors.    
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.xss
+    update:
+      description: XSS Attack - Prevent injection of malicious scripts into trusted webpages.  
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.sqli
+    update:
+      description: SQL Injection Attack - Prohibit unauthorized use of SQL commands to manipulate databases. 
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.sf
+    update:
+      description: Session Fixation Attack - Prevent unauthorized takeover of user sessions by enforcing unique session IDs.          
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.crs.properties.java
+    update:
+      description: Java Attack - Mitigate risks of exploitation targeting Java-based applications or components.     
+  # Link to parameter reference in parameter type descriptions for /v1/security/firewall
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.type
+    update:
+      description: [Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic.  
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.type
+    update:
+      description: [Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic.  
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.type
+    update:
+      description: [Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic. 
+  - target: $.paths['/v1/security/firewall/config'].patch.requestBody.content['application/json'].schema.oneOf[1].properties.value.properties.conditionGroup.items.properties.conditions.items.properties.type
+    update:
+      description: [Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic.  
+  - target: $.paths['/v1/security/firewall/config'].patch.requestBody.content['application/json'].schema.oneOf[2].properties.value.properties.conditionGroup.items.properties.conditions.items.properties.type
+    update:
+      description: [Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic.    
+  # Link to operator reference in operator descriptions for /v1/security/firewall
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.op
+    update:
+      description: [Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value.       
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.op
+    update:
+      description: [Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value.  
+  - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.op
+    update:
+      description: [Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value. 
+  - target: $.paths['/v1/security/firewall/config'].patch.requestBody.content['application/json'].schema.oneOf[1].properties.value.properties.conditionGroup.items.properties.conditions.items.properties.op
+    update:
+      description: [Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value.  
+  - target: $.paths['/v1/security/firewall/config'].patch.requestBody.content['application/json'].schema.oneOf[2].properties.value.properties.conditionGroup.items.properties.conditions.items.properties.op
+    update:
+      description: [Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value.                                                                       
   - target: $.paths['/v1/teams/{teamId}/members/{uid}'].patch.requestBody.content['application/json'].schema.properties['joinedFrom'].properties['ssoUserId'].type
     remove: true
   - target: $.paths['/v1/teams/{teamId}/members/{uid}'].patch.requestBody.content['application/json'].schema.properties['joinedFrom'].properties['ssoUserId']

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -577,40 +577,40 @@ actions:
       type: string
       enum: [managedRules.update]
   # Update CRS object descriptions for /v1/security/firewall/config put responses 200
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs
     update:
       description: Custom Ruleset
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.sd
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.sd
     update:
       description: Scanner Detection - Detect and prevent reconnaissance activities from network scanning tools.
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.ma
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.ma
     update:
       description: Multipart Attack - Block attempts to bypass security controls using multipart/form-data encoding.      
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.lfi
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.lfi
     update:
       description: Local File Inclusion Attack - Prevent unauthorized access to local files through web applications.   
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.rfi
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.rfi
     update:
       description: Remote File Inclusion Attack - Prohibit unauthorized upload or execution of remote files.    
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.rce
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.rce
     update:
       description: Remote Execution Attack - Prevent unauthorized execution of remote scripts or commands.          
   - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.php
     update:
       description: PHP Attack - Safeguard against vulnerability exploits in PHP-based applications.
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.gen
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.gen
     update:
       description: Generic Attack - Provide broad protection from various undefined or novel attack vectors.    
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.xss
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.xss
     update:
       description: XSS Attack - Prevent injection of malicious scripts into trusted webpages.  
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.sqli
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.sqli
     update:
       description: SQL Injection Attack - Prohibit unauthorized use of SQL commands to manipulate databases. 
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.sf
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.sf
     update:
       description: Session Fixation Attack - Prevent unauthorized takeover of user sessions by enforcing unique session IDs.    
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.java
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.java
     update:
       description: Java Attack - Mitigate risks of exploitation targeting Java-based applications or components.    
   # Update CRS object descriptions for /v1/security/firewall/config put requestBody    

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -576,6 +576,42 @@ actions:
     update:
       type: string
       enum: [managedRules.update]
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs
+    update:
+      description: Custom Ruleset
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.sd
+    update:
+      description: Scanner Detection - Detect and prevent reconnaissance activities from network scanning tools.
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.ma
+    update:
+      description: Multipart Attack - Block attempts to bypass security controls using multipart/form-data encoding.      
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.lfi
+    update:
+      description: Local File Inclusion Attack - Prevent unauthorized access to local files through web applications.   
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.rfi
+    update:
+      description: Remote File Inclusion Attack - Prohibit unauthorized upload or execution of remote files.    
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.rce
+    update:
+      description: Remote Execution Attack - Prevent unauthorized execution of remote scripts or commands.          
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.php
+    update:
+      description: PHP Attack - Safeguard against vulnerability exploits in PHP-based applications.
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.gen
+    update:
+      description: Generic Attack - Provide broad protection from various undefined or novel attack vectors.    
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.xss
+    update:
+      description: XSS Attack - Prevent injection of malicious scripts into trusted webpages.  
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.sqli
+    update:
+      description: SQL Injection Attack - Prohibit unauthorized use of SQL commands to manipulate databases. 
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.sf
+    update:
+      description: Session Fixation Attack - Prevent unauthorized takeover of user sessions by enforcing unique session IDs.    
+  - target: $.paths['/v1/security/firewall/config'].put.responses.content['application/json'].schema.properties.crs.properties.java
+    update:
+      description: Java Attack - Mitigate risks of exploitation targeting Java-based applications or components.                                       
   - target: $.paths['/v1/teams/{teamId}/members/{uid}'].patch.requestBody.content['application/json'].schema.properties['joinedFrom'].properties['ssoUserId'].type
     remove: true
   - target: $.paths['/v1/teams/{teamId}/members/{uid}'].patch.requestBody.content['application/json'].schema.properties['joinedFrom'].properties['ssoUserId']

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -577,40 +577,40 @@ actions:
       type: string
       enum: [managedRules.update]
   # Update CRS object descriptions for /v1/security/firewall/config put responses 200
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs
     update:
       description: Custom Ruleset
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.sd
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.sd
     update:
       description: Scanner Detection - Detect and prevent reconnaissance activities from network scanning tools.
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.ma
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.ma
     update:
       description: Multipart Attack - Block attempts to bypass security controls using multipart/form-data encoding.      
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.lfi
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.lfi
     update:
       description: Local File Inclusion Attack - Prevent unauthorized access to local files through web applications.   
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.rfi
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.rfi
     update:
       description: Remote File Inclusion Attack - Prohibit unauthorized upload or execution of remote files.    
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.rce
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.rce
     update:
       description: Remote Execution Attack - Prevent unauthorized execution of remote scripts or commands.          
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.crs.properties.php
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.php
     update:
       description: PHP Attack - Safeguard against vulnerability exploits in PHP-based applications.
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.gen
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.gen
     update:
       description: Generic Attack - Provide broad protection from various undefined or novel attack vectors.    
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.xss
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.xss
     update:
       description: XSS Attack - Prevent injection of malicious scripts into trusted webpages.  
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.sqli
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.sqli
     update:
       description: SQL Injection Attack - Prohibit unauthorized use of SQL commands to manipulate databases. 
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.sf
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.sf
     update:
       description: Session Fixation Attack - Prevent unauthorized takeover of user sessions by enforcing unique session IDs.    
-  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.crs.properties.java
+  - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.active.properties.crs.properties.java
     update:
       description: Java Attack - Mitigate risks of exploitation targeting Java-based applications or components.    
   # Update CRS object descriptions for /v1/security/firewall/config put requestBody    

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -690,35 +690,35 @@ actions:
   # Link to parameter reference in parameter type descriptions for /v1/security/firewall
   - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.type
     update:
-      description: [Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic.  
+      description: "[Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic."  
   - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.type
     update:
-      description: [Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic.  
+      description: "[Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic."  
   - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.type
     update:
-      description: [Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic. 
+      description: "[Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic." 
   - target: $.paths['/v1/security/firewall/config'].patch.requestBody.content['application/json'].schema.oneOf[1].properties.value.properties.conditionGroup.items.properties.conditions.items.properties.type
     update:
-      description: [Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic.  
+      description: "[Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic."  
   - target: $.paths['/v1/security/firewall/config'].patch.requestBody.content['application/json'].schema.oneOf[2].properties.value.properties.conditionGroup.items.properties.conditions.items.properties.type
     update:
-      description: [Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic.    
+      description: "[Parameter](https://vercel.com/docs/security/vercel-waf/rule-configuration#parameters) from the incoming traffic."    
   # Link to operator reference in operator descriptions for /v1/security/firewall
   - target: $.paths['/v1/security/firewall/config/{configVersion}'].get.responses.200.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.op
     update:
-      description: [Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value.       
+      description: "[Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value"       
   - target: $.paths['/v1/security/firewall/config'].put.responses.200.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.op
     update:
-      description: [Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value.  
+      description: "[Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value."  
   - target: $.paths['/v1/security/firewall/config'].put.requestBody.content['application/json'].schema.properties.rules.items.properties.conditionGroup.items.properties.conditions.items.properties.op
     update:
-      description: [Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value. 
+      description: "[Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value." 
   - target: $.paths['/v1/security/firewall/config'].patch.requestBody.content['application/json'].schema.oneOf[1].properties.value.properties.conditionGroup.items.properties.conditions.items.properties.op
     update:
-      description: [Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value.  
+      description: "[Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value."  
   - target: $.paths['/v1/security/firewall/config'].patch.requestBody.content['application/json'].schema.oneOf[2].properties.value.properties.conditionGroup.items.properties.conditions.items.properties.op
     update:
-      description: [Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value.                                                                       
+      description: "[Operator](https://vercel.com/docs/security/vercel-waf/rule-configuration#operators) used to compare the parameter with a value"                                                                       
   - target: $.paths['/v1/teams/{teamId}/members/{uid}'].patch.requestBody.content['application/json'].schema.properties['joinedFrom'].properties['ssoUserId'].type
     remove: true
   - target: $.paths['/v1/teams/{teamId}/members/{uid}'].patch.requestBody.content['application/json'].schema.properties['joinedFrom'].properties['ssoUserId']


### PR DESCRIPTION
## Reference
https://www.notion.so/vercel/Firewall-API-Acronyms-a8c5fc6e24bb4f23bb02e329ee673d8d?pvs=4

## Description
Adding descriptions for the following objects:
- CRS elements - explain what each means
- ConditionGroup operations (linking to docs)
- ConditionGroup parameters (linking to docs)

## Testing
Ran speakeasy locally which ran successfully and got the attached spec
[vercel-spec.json](https://github.com/user-attachments/files/18186894/vercel-spec.json)
Search for "Scanner Detection - Detect and prevent reconnaissance activities from network scanning tools." as an example and you should find it in 3 places for the descriptions

