### PR TITLE
Remove overlay dup fix

### DIFF
--- a/overlay.yaml
+++ b/overlay.yaml
@@ -44,10 +44,6 @@ actions:
         description: Update the fields of a project using either its name or id.
         position: 2
   # Fixing lint and TS issues from source
-  - target: $["paths"]["/v13/deployments"]["post"]["parameters"][0]
-    remove: true
-  - target: $["paths"]["/v13/deployments"]["post"]["parameters"][2]
-    remove: true
   - target: $["paths"]["/v1/domains/{domain}/registry"]["get"]["parameters"]
     update:
       - name: domain


### PR DESCRIPTION
Since [this](https://github.com/vercel/api/pull/35450) merged, we don't need this duplicate param removal in the overlay