### PR TITLE
fix: removed unnecessary duplicate parameter handling in overlay for `GET /teams/{teamId}`

### DIFF
--- a/overlay.yaml
+++ b/overlay.yaml
@@ -124,8 +124,6 @@ actions:
         schema:
           type: string
           description: The unique team identifier
-  - target: $["paths"]["/v2/teams/{teamId}"]["get"]["parameters"][0]
-    remove: true
   - target: $["paths"]["/v2/teams/{teamId}"]["get"]["parameters"][?(@.name == 'teamId')]["required"]
     update: true
   - target: $["paths"]["/v1/teams/{teamId}/invites/{inviteId}"]["delete"]["parameters"]


### PR DESCRIPTION
### Summary

Before https://github.com/vercel/api/pull/35450 merged, certain paths needed to be altered to account for duplicate parameters that would make the specification invalid. `GET /teams/{teamId}` is one of them, as it had this specification [prior to the change](https://api-q20qvmd9s.vercel.sh):

```jsonc
{
  "parameters": [
    {
      "name": "slug",
      "in": "query",
      "schema": {
        "type": "string"
      }
    },
    {
      "description": "The Team identifier to perform the request on behalf of.",
      "in": "path",
      "name": "teamId",
      "schema": {
        "type": "string"
      },
      "required": false
    },
    {
      "description": "The Team slug to perform the request on behalf of.",
      "in": "query",
      "name": "slug",
      "schema": {
        "type": "string"
      }
    }
  ]
  // ...
}
```

The current specification looks like this

```jsonc
{
  // ...
  "parameters": [
    {
      "name": "slug",
      "in": "query",
      "schema": {
        "type": "string"
      }
    },
    {
      "description": "The Team identifier to perform the request on behalf of.",
      "in": "path",
      "name": "teamId",
      "schema": {
        "type": "string"
      },
      "required": false
    }
  ]
  // ...
}
```

which renders the removal of `parameters[0]` unnecessary.