### PR TITLE
fix: suppress `validate-composite-schemas` warning

### DIFF
--- a/.speakeasy/lint.yaml
+++ b/.speakeasy/lint.yaml
@@ -6,3 +6,4 @@ rulesets:
       - speakeasy-generation
     rules:
       path-params: { severity: warn }
+      validate-composite-schemas: { severity: warn }


### PR DESCRIPTION
Fixes errors of the kind

```bash
ERROR    validation error: [line 5472] validate-composite-schemas - empty oneOf keyword found
ERROR    validation error: [line 5472] validate-composite-schemas - empty oneOf keyword found
ERROR    validation error: [line 27456] validate-composite-schemas - empty oneOf keyword found
ERROR    validation error: [line 27456] validate-composite-schemas - empty oneOf keyword found
ERROR    validation error: [line 31195] validate-composite-schemas - empty oneOf keyword found
ERROR    validation error: [line 31195] validate-composite-schemas - empty oneOf keyword found
ERROR    validation error: [line 35064] validate-composite-schemas - empty oneOf keyword found
ERROR    validation error: [line 35064] validate-composite-schemas - empty oneOf keyword found
ERROR    validation error: [line 38693] validate-composite-schemas - empty oneOf keyword found
ERROR    validation error: [line 38693] validate-composite-schemas - empty oneOf keyword found
```
