### PR TITLE
fix: update method signatures for v1/installations operations

### DIFF
--- a/overlay.yaml
+++ b/overlay.yaml
@@ -1435,3 +1435,23 @@ actions:
           total:
             type: integer
             minimum: 0 # Total number of allowed requests
+  - target: >-
+      $["paths"]["/v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/items"]["post"]
+    update:
+      x-speakeasy-name-override: createInstallationIntegrationConfiguration
+  - target: >-
+      $["paths"]["/v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/items/{itemId}"]["patch"]
+    update:
+      x-speakeasy-name-override: updateInstallationIntegrationConfiguration
+  - target: >-
+      $["paths"]["/v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/items/{itemId}"]["delete"]
+    update:
+      x-speakeasy-name-override: deleteInstallationIntegrationConfiguration
+  - target: >-
+      $["paths"]["/v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/edge-config"]["head"]
+    update:
+      x-speakeasy-name-override: createInstallationIntegrationEdgeConfig
+  - target: >-
+      $["paths"]["/v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/edge-config"]["put"]
+    update:
+      x-speakeasy-name-override: updateInstallationIntegratioEdgeConfig

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -1454,4 +1454,4 @@ actions:
   - target: >-
       $["paths"]["/v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/edge-config"]["put"]
     update:
-      x-speakeasy-name-override: updateInstallationIntegratioEdgeConfig
+      x-speakeasy-name-override: updateInstallationIntegrationEdgeConfig


### PR DESCRIPTION
Before: 
[postV1InstallationsIntegrationConfigurationIdResourcesResourceIdExperimentationItems](https://github.com/vercel/sdk/blob/main/docs/sdks/marketplace/README.md#postv1installationsintegrationconfigurationidresourcesresourceidexperimentationitems) - Create one or multiple experimentation items
[patchV1InstallationsIntegrationConfigurationIdResourcesResourceIdExperimentationItemsItemId](https://github.com/vercel/sdk/blob/main/docs/sdks/marketplace/README.md#patchv1installationsintegrationconfigurationidresourcesresourceidexperimentationitemsitemid) - Patch an existing experimentation item
[deleteV1InstallationsIntegrationConfigurationIdResourcesResourceIdExperimentationItemsItemId](https://github.com/vercel/sdk/blob/main/docs/sdks/marketplace/README.md#deletev1installationsintegrationconfigurationidresourcesresourceidexperimentationitemsitemid) - Delete an existing experimentation item
[headV1InstallationsIntegrationConfigurationIdResourcesResourceIdExperimentationEdgeConfig](https://github.com/vercel/sdk/blob/main/docs/sdks/marketplace/README.md#headv1installationsintegrationconfigurationidresourcesresourceidexperimentationedgeconfig) - Get the data of a user-provided Edge Config
[putV1InstallationsIntegrationConfigurationIdResourcesResourceIdExperimentationEdgeConfig](https://github.com/vercel/sdk/blob/main/docs/sdks/marketplace/README.md#putv1installationsintegrationconfigurationidresourcesresourceidexperimentationedgeconfig) - Push data into a user-provided Edge Config


After:

![CleanShot 2025-03-13 at 14 15 07@2x](https://github.com/user-attachments/assets/02b7c6f5-5624-4bd3-85b9-1fe6b2fc159c)
