### PR TITLE
fix: update overlay to remove not schema 

### DIFF
--- a/overlay.yaml
+++ b/overlay.yaml
@@ -1451,3 +1451,34 @@ actions:
       $["paths"]["/v1/installations/{integrationConfigurationId}/resources/{resourceId}/experimentation/edge-config"]["put"]
     update:
       x-speakeasy-name-override: updateInstallationIntegrationEdgeConfig
+  - target: $["paths"]["/v1/security/firewall/config"]["put"]["requestBody"]["content"]["application/json"]["schema"]["properties"]["managedRules"]["additionalProperties"]["anyOf"][*]
+    remove: true
+  - target: $["paths"]["/v1/security/firewall/config"]["put"]["requestBody"]["content"]["application/json"]["schema"]["properties"]["managedRules"]["additionalProperties"]["anyOf"]
+    update:
+      - type: object
+        properties:
+          active:
+            type: boolean
+          action:
+            type: string
+            enum:
+              - log
+              - challenge
+              - deny
+          ruleGroups:
+            type: object
+            additionalProperties:
+              type: object
+              properties:
+                active:
+                  type: boolean
+                action:
+                  type: string
+                  enum:
+                    - log
+                    - challenge
+                    - deny
+              additionalProperties: false
+        required:
+          - active
+        additionalProperties: false


### PR DESCRIPTION
`WARN    skipping: putFirewallConfig	{"error":"unsupported: not schemas unsupported (line 50896)","operation":"putFirewallConfig","type":"paths"}`

We don't yet support the "not" schema syntax. Removing that for now via the overlay so the whole `PUT` operation `v1/security/firewall/config` is not skipped. 