### PR TITLE
Mintlify fix

### DIFF
--- a/mintlify-overlay.yaml
+++ b/mintlify-overlay.yaml
@@ -18,3 +18,5 @@ actions:
     remove: true
   - target: $.paths..requestBody..[?(@.required && length(@.required) == 0)].required
     remove: true    
+  - target: $.paths..requestBody..["application/json"]..["private"]
+    remove: true  

--- a/mintlify-overlay.yaml
+++ b/mintlify-overlay.yaml
@@ -18,5 +18,6 @@ actions:
     remove: true
   - target: $.paths..requestBody..[?(@.required && length(@.required) == 0)].required
     remove: true    
-  - target: $.paths..requestBody..["application/json"]..["private"]
+  # Removing any instances in the request body that have "private": true as this break the mintlify linting when generating the docs
+  - target: $.paths..requestBody..[?(@.private == true)].private
     remove: true  


### PR DESCRIPTION
Removing any instances in the request body that have "private": true as this break the mintlify linting when generating the docs