### PR TITLE
Disable sdk-only-errors overlay

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -6,7 +6,6 @@ sources:
             - location: https://openapi.vercel.sh/
         overlays:
             - location: overlay.yaml
-            - location: sdk-only-errors.yaml
             - location: mintlify-overlay.yaml
             - location: tests-overlay.yaml
         output: vercel-spec.json


### PR DESCRIPTION
So we can test deployment events 200 response from source