### PR TITLE
SDK Generation failing

### DIFF
--- a/overlay.yaml
+++ b/overlay.yaml
@@ -848,6 +848,7 @@ actions:
         - integration-resource.project-disconnected
         - project.created
         - project.removed
+        - project.domain.verified
         - project.rolling-release.started
         - project.rolling-release.aborted
         - project.rolling-release.completed
@@ -898,6 +899,7 @@ actions:
         - integration-resource.project-disconnected
         - project.created
         - project.removed
+        - project.domain.verified
         - project.rolling-release.started
         - project.rolling-release.aborted
         - project.rolling-release.completed
@@ -948,6 +950,7 @@ actions:
         - integration-resource.project-disconnected
         - project.created
         - project.removed
+        - project.domain.verified
         - project.rolling-release.started
         - project.rolling-release.aborted
         - project.rolling-release.completed
@@ -998,6 +1001,7 @@ actions:
         - integration-resource.project-disconnected
         - project.created
         - project.removed
+        - project.domain.verified
         - project.rolling-release.started
         - project.rolling-release.aborted
         - project.rolling-release.completed
@@ -1048,6 +1052,7 @@ actions:
         - integration-resource.project-disconnected
         - project.created
         - project.removed
+        - project.domain.verified
         - project.rolling-release.started
         - project.rolling-release.aborted
         - project.rolling-release.completed


### PR DESCRIPTION
https://github.com/vercel/sdk/actions/runs/15263788486/job/42925878579#step:5:2097

`project.domain.verified` needs to be added in the speakeasy-enum overlay update

Tested locally here:
https://go.speakeasy.com/CGUOE3a
https://go.speakeasy.com/1aQH4PL