### PR TITLE
feat: add domain renewal webhook events

### DIFF
--- a/overlay.yaml
+++ b/overlay.yaml
@@ -816,6 +816,9 @@ actions:
         - domain.certificate.renew
         - domain.certificate.renew.failed
         - domain.certificate.deleted
+        - domain.renewal
+        - domain.renewal.failed
+        - domain.auto-renew.changed
         - deployment.created
         - deployment.error
         - deployment.canceled
@@ -865,7 +868,7 @@ actions:
         - marketplace.invoice.notpaid
         - marketplace.invoice.refunded
         - observability.anomaly
-        - test-webhook        
+        - test-webhook
   - target: $.paths['/v1/webhooks'].post.requestBody.content['application/json'].schema.properties.events.items
     update:
       x-speakeasy-enums:
@@ -881,6 +884,9 @@ actions:
         - domain.certificate.renew
         - domain.certificate.renew.failed
         - domain.certificate.deleted
+        - domain.renewal
+        - domain.renewal.failed
+        - domain.auto-renew.changed
         - deployment.created
         - deployment.error
         - deployment.canceled
@@ -930,7 +936,7 @@ actions:
         - marketplace.invoice.notpaid
         - marketplace.invoice.refunded
         - observability.anomaly
-        - test-webhook    
+        - test-webhook
   - target: $.paths['/v1/webhooks'].get.responses['200'].content['application/json'].schema.oneOf[0].items.properties.events.items
     update:
       x-speakeasy-enums:
@@ -946,6 +952,9 @@ actions:
         - domain.certificate.renew
         - domain.certificate.renew.failed
         - domain.certificate.deleted
+        - domain.renewal
+        - domain.renewal.failed
+        - domain.auto-renew.changed
         - deployment.created
         - deployment.error
         - deployment.canceled
@@ -995,7 +1004,7 @@ actions:
         - marketplace.invoice.notpaid
         - marketplace.invoice.refunded
         - observability.anomaly
-        - test-webhook    
+        - test-webhook
   - target: $.paths['/v1/webhooks'].get.responses['200'].content['application/json'].schema.oneOf[1].items.properties.events.items
     update:
       x-speakeasy-enums:
@@ -1011,6 +1020,9 @@ actions:
         - domain.certificate.renew
         - domain.certificate.renew.failed
         - domain.certificate.deleted
+        - domain.renewal
+        - domain.renewal.failed
+        - domain.auto-renew.changed
         - deployment.created
         - deployment.error
         - deployment.canceled
@@ -1060,7 +1072,7 @@ actions:
         - marketplace.invoice.notpaid
         - marketplace.invoice.refunded
         - observability.anomaly
-        - test-webhook    
+        - test-webhook
   - target: $.paths['/v1/webhooks/{id}'].get.responses['200'].content['application/json'].schema.properties.events.items
     update:
       x-speakeasy-enums:
@@ -1076,6 +1088,9 @@ actions:
         - domain.certificate.renew
         - domain.certificate.renew.failed
         - domain.certificate.deleted
+        - domain.renewal
+        - domain.renewal.failed
+        - domain.auto-renew.changed
         - deployment.created
         - deployment.error
         - deployment.canceled
@@ -1125,10 +1140,10 @@ actions:
         - marketplace.invoice.notpaid
         - marketplace.invoice.refunded
         - observability.anomaly
-        - test-webhook       
+        - test-webhook
   # Remove blank required array
   - target: $.paths['/v9/projects/{idOrName}/custom-environments/{environmentSlugOrId}'].delete.requestBody["content"]["application/json"]["schema"].required
-    remove: true         
+    remove: true
   # Make requestbody required
   - target: $.paths['/v1/access-groups/{idOrName}'].post.requestBody
     update:


### PR DESCRIPTION
This PR adds support for new domain renewal webhook events to the Vercel SDK.

## Changes
- Add `domain.renewal` event for domain renewal notifications
- Add `domain.renewal.failed` event for failed renewal notifications  
- Add `domain.auto-renew.changed` event for auto-renewal setting changes
- Clean up trailing whitespace in webhook event lists

## Details
These new webhook events provide better visibility into domain renewal processes, allowing developers to:
- Monitor successful domain renewals
- Handle failed renewal scenarios
- Track changes to auto-renewal settings

The events are added to all relevant webhook endpoint schemas in the overlay.yaml file to ensure consistency across the API.