### PR TITLE
chore: replace type: null with string

### DIFF
--- a/mintlify-overlay.yaml
+++ b/mintlify-overlay.yaml
@@ -21,5 +21,6 @@ actions:
   # Removing any instances in the request body that have "private": true as this break the mintlify linting when generating the docs
   - target: $.paths..requestBody..[?(@.private == true)].private
     remove: true  
-  - target: $.paths..requestBody..properties.id[?(@.type == "null")]
-    remove: true   
+  - target: '$..[?(@.type == "null")]'
+    update:
+      type: "string"


### PR DESCRIPTION
To address lint `ERROR` in this generation https://github.com/vercel/sdk/actions/runs/15789878983/job/44513689923

> ERROR    validation error: [line 60432] validate-json-schema - OpenAPI document invalid: value must be one of "array", "boolean", "integer", "number", "object", "string" - https://spec.openapis.org/oas/3.0/schema/2021-09-28#/definitions/Schema/properties/type/enum

To fix this we target the parent objects that contain `type: "null"` and updates the entire object with `type: "string"`

```
overlay: 1.0.0
x-speakeasy-jsonpath: rfc9535
info:
  title: Replace invalid JSONSchema null types with string
  version: 1.0.0
actions:
  - target: '$..[?(@.type == "null")]'
    update:
      type: "string"
```

https://overlay.speakeasy.com/?s=aHR0cHM6Ly84ZXVkbGhiem5nZGR3ZDhyLnB1YmxpYy5ibG9iLnZlcmNlbC1zdG9yYWdlLmNvbS9zaGFyZS11cmxzL0o1cDBDTHo%2FZG93bmxvYWQ9MQ%3D%3D