### PR TITLE
fix: change jsonpath for "describe" fields in "schema" objects

### DIFF
--- a/mintlify-overlay.yaml
+++ b/mintlify-overlay.yaml
@@ -26,5 +26,5 @@ actions:
     update:
       type: "string"  
   # Property describe is not valid in openapi spec and breaks mintlify generation
-  - target: '$..[?(@.describe)]'
-    remove: true      
+  - target: "$..schema.describe"
+    remove: true


### PR DESCRIPTION
The existing JSONPath to remove `describe` fields will also delete the object that field belongs to. This was causing [action failures](https://github.com/vercel/sdk/actions/runs/16208638753/job/45764364350#step:5:2289), because `schema` objects on params were being deleted if they contained a `describe` field. The new JSONPath will only delete the `describe` field itself.