### PR TITLE
fix sdk gen failure

### DIFF
--- a/mintlify-overlay.yaml
+++ b/mintlify-overlay.yaml
@@ -26,5 +26,5 @@ actions:
     update:
       type: "string"  
   # Property describe is not valid in openapi spec and breaks mintlify generation
-  - target: '$..[?(@.describe)]'
+  - target: "$..schema.describe"
     remove: true      

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -830,6 +830,7 @@ actions:
         - deployment.integration.action.cancel
         - deployment.integration.action.cleanup
         - deployment.checkrun.start
+        - deployment.checkrun.cancel
         - edge-config.created
         - edge-config.deleted
         - edge-config.items.updated
@@ -899,6 +900,7 @@ actions:
         - deployment.integration.action.cancel
         - deployment.integration.action.cleanup
         - deployment.checkrun.start
+        - deployment.checkrun.cancel
         - edge-config.created
         - edge-config.deleted
         - edge-config.items.updated
@@ -968,6 +970,7 @@ actions:
         - deployment.integration.action.cancel
         - deployment.integration.action.cleanup
         - deployment.checkrun.start
+        - deployment.checkrun.cancel
         - edge-config.created
         - edge-config.deleted
         - edge-config.items.updated
@@ -1037,6 +1040,7 @@ actions:
         - deployment.integration.action.cancel
         - deployment.integration.action.cleanup
         - deployment.checkrun.start
+        - deployment.checkrun.cancel
         - edge-config.created
         - edge-config.deleted
         - edge-config.items.updated
@@ -1106,6 +1110,7 @@ actions:
         - deployment.integration.action.cancel
         - deployment.integration.action.cleanup
         - deployment.checkrun.start
+        - deployment.checkrun.cancel
         - edge-config.created
         - edge-config.deleted
         - edge-config.items.updated


### PR DESCRIPTION
- "spec" parent being removed with "describe"
- speakeasy-enums length not the same as source