### PR TITLE
chore: Enable new changelog in PR Message, Commit Message, Release Notes

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -25,6 +25,8 @@ jobs:
       pnpm_version: 8.3.1
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
+      enable_sdk_changelog_july_2025: true
+      target: vercel
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   publish:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+    with:
+      enable_sdk_changelog_july_2025: true
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN_ELEVATED }}


### PR DESCRIPTION
## PR to enable new changelog from Speakeasy.
**The new changelog more accurately captures the changes introduced in the SDK by  Speakeasy (highlighted in the screenshot)**

<img width="882" height="830" alt="new changelog v1" src="https://github.com/user-attachments/assets/2e2e8df2-9b07-422d-b671-2a17de18047d" />

