### PR TITLE
chore: Update keys for enabling new changelog

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -25,7 +25,7 @@ jobs:
       pnpm_version: 8.3.1
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
-      enable_sdk_changelog_july_2025: true
+      enable_sdk_changelog: true
       target: vercel
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -14,7 +14,7 @@ jobs:
   publish:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
     with:
-      enable_sdk_changelog_july_2025: true
+      enable_sdk_changelog: true
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN_ELEVATED }}


### PR DESCRIPTION
There was a change in the keys for enabling new changelog. 
Related to this old PR - https://github.com/vercel/sdk/pull/127
