### PR TITLE
Change runner to ubuntu-latest-4-cores for SDK generation

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -20,6 +20,7 @@ jobs:
   generate:
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
     with:
+      runs-on: ubuntu-latest-4-cores # beefier runner to avoid OOM
       force: ${{ github.event.inputs.force }}
       mode: pr
       pnpm_version: 8.3.1


### PR DESCRIPTION
Updated the runner to a beefier version to avoid OOM errors during SDK generation.