### PR TITLE
Remove overlay SDK global error additions

### DIFF
--- a/overlay.yaml
+++ b/overlay.yaml
@@ -1434,11 +1434,6 @@ actions:
       example: "pnpm install"
   - target: $.paths['/v1/projects/{idOrName}/custom-environments/{environmentSlugOrId}'].delete.requestBody.content["application/json"].schema.required
     remove: true
-    update:
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/VercelRateLimitError" # Reference to the Rate Limit error schema
   # Define custom error schemas under the components section
   - target: $["components"]["schemas"]
     update:

--- a/overlay.yaml
+++ b/overlay.yaml
@@ -1434,26 +1434,6 @@ actions:
       example: "pnpm install"
   - target: $.paths['/v1/projects/{idOrName}/custom-environments/{environmentSlugOrId}'].delete.requestBody.content["application/json"].schema.required
     remove: true
-  # Update response schemas for various HTTP status codes across all paths and operations
-  - target: $["paths"][*][*]["responses"]["400"]
-    update:
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/VercelBadRequestError" # Reference to the Bad Request error schema
-  - target: $["paths"][*][*]["responses"]["401"]
-    update:
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/VercelForbiddenError" # Reference to the Forbidden error schema
-  - target: $["paths"][*][*]["responses"]["404"]
-    update:
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/VercelNotFoundError" # Reference to the Not Found error schema
-  - target: $["paths"][*][*]["responses"]["429"]
     update:
       content:
         application/json:


### PR DESCRIPTION
It's overriding error response set at the level of individual endpoints
I ran the generation locally with this change and it passes