### PR TITLE
move to lax mode

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -65,7 +65,7 @@ typescript:
   inferUnionDiscriminators: true
   inputModelSuffix: input
   jsonpath: legacy
-  laxMode: strict
+  laxMode: lax
   maxMethodParams: 0
   methodArguments: require-security-and-request
   modelPropertyCasing: camel


### PR DESCRIPTION
Ref: https://github.com/vercel/sdk/issues/30

This issue could be solved by enabling [laxMode: lax](https://www.speakeasy.com/blog/typescript-forward-compatibility#lax-mode)[ in gen.yaml](https://www.speakeasy.com/blog/typescript-forward-compatibility#lax-mode) which includes some coercion and would have coerced this string to number.

