### PR TITLE
fix: use PR_CREATION_PAT to enable auto-merge and downstream workflow triggers

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -30,6 +30,6 @@ jobs:
       environment: |
         NODE_OPTIONS="--max-old-space-size=12288"
     secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      github_access_token: ${{ secrets.PR_CREATION_PAT }}
       npm_token: ${{ secrets.NPM_TOKEN_ELEVATED }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
## Summary

- Replaces `GITHUB_TOKEN` with `PR_CREATION_PAT` as the `github_access_token` in `sdk_generation.yaml`
- GitHub's default `GITHUB_TOKEN` cannot trigger other workflows, which was preventing Speakeasy-generated PRs from auto-merging and subsequently triggering `sdk_publish.yaml`
- Using a fine-grained PAT (stored as the `PR_CREATION_PAT` repo secret) bypasses this GitHub restriction

## Context

Discussed in [#shared-speakeasy](https://vercel.slack.com/archives/C074TFBJJ6L/p1775169615.539369) — Speakeasy confirmed that using a PAT (or their GitHub App) is the correct fix for this workflow-trigger limitation. Ash from Speakeasy: _"we do occasionally see issues when customers aren't using PATs due to Github's protections."_

## Pre-requisites

Ensure the `PR_CREATION_PAT` secret is added to this repo (Settings → Secrets → Actions) with at least **Pull requests Read/Write** and **repo** access.

## Test plan

- [ ] Confirm `PR_CREATION_PAT` secret is set in repo settings
- [ ] Trigger the Generate workflow manually and verify the Speakeasy PR is created
- [ ] Verify tests run and auto-merge fires, triggering `sdk_publish.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)