### PR TITLE
fix: use PR_CREATION_PAT for auto-merge to trigger sdk_publish workflow

### DIFF
--- a/.github/workflows/auto_merge_speakeasy.yaml
+++ b/.github/workflows/auto_merge_speakeasy.yaml
@@ -22,4 +22,4 @@ jobs:
             gh pr merge "$PR_NUMBER" --auto --squash --repo "${{ github.repository }}"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_CREATION_PAT }}


### PR DESCRIPTION
## Summary
- Switches `auto_merge_speakeasy.yaml` from `GITHUB_TOKEN` to `PR_CREATION_PAT` for the merge step
- `GITHUB_TOKEN`-authored pushes to `main` do not trigger downstream workflow runs (GitHub limitation), causing `sdk_publish.yaml` to be skipped after Speakeasy PRs are auto-merged
- Using `PR_CREATION_PAT` ensures the push to `main` is attributed to a real actor and fires the publish workflow

## Test plan
- [ ] Merge this PR
- [ ] Trigger a Speakeasy generation run and confirm the resulting PR is auto-merged
- [ ] Verify `sdk_publish.yaml` runs after the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)