### PR TITLE
fix: use PR_CREATION_PAT in test workflow for Speakeasy repo clone

### DIFF
--- a/.github/workflows/sdk_test.yaml
+++ b/.github/workflows/sdk_test.yaml
@@ -24,5 +24,5 @@ jobs:
       env_vars: |
         NODE_OPTIONS=--max-old-space-size=6144
     secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      github_access_token: ${{ secrets.PR_CREATION_PAT }}
       speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
## Summary
- Switches `sdk_test.yaml` from `GITHUB_TOKEN` to `PR_CREATION_PAT` as the `github_access_token` passed to the Speakeasy reusable test workflow
- `GITHUB_TOKEN` has restricted scope when passed as a secret into an external Docker action, causing the Speakeasy test action to fail when cloning the repo branch (`couldn't find remote ref`)
- Consistent with the fixes applied in #262 (auto-merge) and #261 (generation)

## Test plan
- [ ] Merge this PR
- [ ] Trigger a Speakeasy generation run and confirm the test workflow passes on the resulting PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)