### PR TITLE
fix: add id-token write permission for OIDC in sdk_publish workflow

### DIFF
--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -2,6 +2,7 @@ name: Publish
 permissions:
   checks: write
   contents: write
+  id-token: write
   pull-requests: write
   statuses: write
 'on':


### PR DESCRIPTION
## Summary

- Speakeasy's `sdk-generation-action` `v15` tag was updated on 2026-04-13 (release v15.60.1) to add a `publish-mcp-registry` job requiring OIDC authentication (`id-token: write`)
- Our `sdk_publish.yaml` didn't grant `id-token: write`, causing GitHub to reject the reusable workflow call at startup — resulting in `startup_failure` on all publish runs since the 1.19.35 push
- Adds `id-token: write` to the calling workflow's `permissions` block to unblock the publish pipeline

## Test plan

- [ ] Merge this PR — the next push to main touching `RELEASES.md` should trigger a successful publish run
- [ ] Manually re-trigger the `sdk_publish` workflow to confirm the `startup_failure` is resolved and 1.19.35 publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)