### PR TITLE
fix(projects): default createprojectenv type to sensitive

### DIFF
--- a/src/__tests__/projects.test.ts
+++ b/src/__tests__/projects.test.ts
@@ -256,6 +256,65 @@ test("Projects Create Project Env", async () => {
   expect(result).toBeDefined();
 });
 
+test("Projects Create Project Env Defaults Type", async () => {
+  const testHttpClient = createTestHTTPClient("createProjectEnv");
+
+  const vercel = new Vercel({
+    serverURL: process.env["TEST_SERVER_URL"] ?? "http://localhost:18080",
+    httpClient: testHttpClient,
+    bearerToken: "<YOUR_BEARER_TOKEN_HERE>",
+  });
+
+  const result = await vercel.projects.createProjectEnv({
+    idOrName: "prj_XLKmu1DyR1eY7zq8UgeRKbA7yVLA",
+    upsert: "true",
+    teamId: "team_1a2b3c4d5e6f7g8h9i0j1k2l",
+    slug: "my-team-url-slug",
+    requestBody: {
+      key: "API_TOKEN",
+      value: "super-secret-value",
+      target: [
+        "preview",
+      ],
+      comment: "preview token",
+      customEnvironmentIds: [
+        "env_1234567890",
+      ],
+    },
+  });
+  expect(result).toBeDefined();
+});
+
+test("Projects Create Project Env Allows Plain For Development", async () => {
+  const testHttpClient = createTestHTTPClient("createProjectEnv");
+
+  const vercel = new Vercel({
+    serverURL: process.env["TEST_SERVER_URL"] ?? "http://localhost:18080",
+    httpClient: testHttpClient,
+    bearerToken: "<YOUR_BEARER_TOKEN_HERE>",
+  });
+
+  const result = await vercel.projects.createProjectEnv({
+    idOrName: "prj_XLKmu1DyR1eY7zq8UgeRKbA7yVLA",
+    upsert: "true",
+    teamId: "team_1a2b3c4d5e6f7g8h9i0j1k2l",
+    slug: "my-team-url-slug",
+    requestBody: {
+      key: "LOCAL_ONLY_VALUE",
+      value: "value-for-dev",
+      type: "plain",
+      target: [
+        "development",
+      ],
+      comment: "development-only plain variable",
+      customEnvironmentIds: [
+        "env_1234567890",
+      ],
+    },
+  });
+  expect(result).toBeDefined();
+});
+
 test("Projects Get Project Env", async () => {
   const testHttpClient = createTestHTTPClient("getProjectEnv");
 

--- a/src/funcs/projectsCreateProjectEnv.ts
+++ b/src/funcs/projectsCreateProjectEnv.ts
@@ -30,6 +30,40 @@ import { VercelError } from "../models/vercelerror.js";
 import { APICall, APIPromise } from "../types/async.js";
 import { Result } from "../types/fp.js";
 
+type EnvVarType = "system" | "encrypted" | "plain" | "sensitive";
+
+type EnvVarLike = {
+  type?: EnvVarType;
+  target?: Array<string>;
+};
+
+function withDefaultEnvType<T extends EnvVarLike>(envVar: T): T {
+  if (envVar.type) {
+    return envVar;
+  }
+
+  return {
+    ...envVar,
+    type: "sensitive",
+  };
+}
+
+export function applyDefaultCreateProjectEnvType(
+  request: CreateProjectEnvRequest,
+): CreateProjectEnvRequest {
+  if (Array.isArray(request.requestBody)) {
+    return {
+      ...request,
+      requestBody: request.requestBody.map((item) => withDefaultEnvType(item)),
+    };
+  }
+
+  return {
+    ...request,
+    requestBody: withDefaultEnvType(request.requestBody),
+  };
+}
+
 /**
  * Create one or more environment variables
  *
@@ -82,8 +116,10 @@ async function $do(
     APICall,
   ]
 > {
+  const requestWithDefaults = applyDefaultCreateProjectEnvType(request);
+
   const parsed = safeParse(
-    request,
+    requestWithDefaults,
     (value) => CreateProjectEnvRequest$outboundSchema.parse(value),
     "Input validation failed",
   );

--- a/src/models/createprojectenvop.ts
+++ b/src/models/createprojectenvop.ts
@@ -46,7 +46,7 @@ export type CreateProjectEnv22 = {
   /**
    * The type of environment variable
    */
-  type: CreateProjectEnv2Type;
+  type?: CreateProjectEnv2Type | undefined;
   /**
    * The target environment of the environment variable
    */
@@ -98,7 +98,7 @@ export type CreateProjectEnv21 = {
   /**
    * The type of environment variable
    */
-  type: TwoType;
+  type?: TwoType | undefined;
   /**
    * The target environment of the environment variable
    */
@@ -156,7 +156,7 @@ export type CreateProjectEnv12 = {
   /**
    * The type of environment variable
    */
-  type: CreateProjectEnv1Type;
+  type?: CreateProjectEnv1Type | undefined;
   /**
    * The target environment of the environment variable
    */
@@ -208,7 +208,7 @@ export type CreateProjectEnv11 = {
   /**
    * The type of environment variable
    */
-  type: OneType;
+  type?: OneType | undefined;
   /**
    * The target environment of the environment variable
    */
@@ -733,7 +733,7 @@ export const CreateProjectEnv22$inboundSchema: z.ZodType<
 > = z.object({
   key: types.string(),
   value: types.string(),
-  type: CreateProjectEnv2Type$inboundSchema,
+  type: types.optional(CreateProjectEnv2Type$inboundSchema),
   target: types.optional(z.array(CreateProjectEnv2Target$inboundSchema)),
   gitBranch: z.nullable(types.string()).optional(),
   comment: types.optional(types.string()),
@@ -743,7 +743,7 @@ export const CreateProjectEnv22$inboundSchema: z.ZodType<
 export type CreateProjectEnv22$Outbound = {
   key: string;
   value: string;
-  type: string;
+  type?: string | undefined;
   target?: Array<string> | undefined;
   gitBranch?: string | null | undefined;
   comment?: string | undefined;
@@ -758,7 +758,7 @@ export const CreateProjectEnv22$outboundSchema: z.ZodType<
 > = z.object({
   key: z.string(),
   value: z.string(),
-  type: CreateProjectEnv2Type$outboundSchema,
+  type: CreateProjectEnv2Type$outboundSchema.optional(),
   target: z.array(CreateProjectEnv2Target$outboundSchema).optional(),
   gitBranch: z.nullable(z.string()).optional(),
   comment: z.string().optional(),
@@ -804,7 +804,7 @@ export const CreateProjectEnv21$inboundSchema: z.ZodType<
 > = z.object({
   key: types.string(),
   value: types.string(),
-  type: TwoType$inboundSchema,
+  type: types.optional(TwoType$inboundSchema),
   target: z.array(TwoTarget$inboundSchema),
   gitBranch: z.nullable(types.string()).optional(),
   comment: types.optional(types.string()),
@@ -814,7 +814,7 @@ export const CreateProjectEnv21$inboundSchema: z.ZodType<
 export type CreateProjectEnv21$Outbound = {
   key: string;
   value: string;
-  type: string;
+  type?: string | undefined;
   target: Array<string>;
   gitBranch?: string | null | undefined;
   comment?: string | undefined;
@@ -829,7 +829,7 @@ export const CreateProjectEnv21$outboundSchema: z.ZodType<
 > = z.object({
   key: z.string(),
   value: z.string(),
-  type: TwoType$outboundSchema,
+  type: TwoType$outboundSchema.optional(),
   target: z.array(TwoTarget$outboundSchema),
   gitBranch: z.nullable(z.string()).optional(),
   comment: z.string().optional(),
@@ -922,7 +922,7 @@ export const CreateProjectEnv12$inboundSchema: z.ZodType<
 > = z.object({
   key: types.string(),
   value: types.string(),
-  type: CreateProjectEnv1Type$inboundSchema,
+  type: types.optional(CreateProjectEnv1Type$inboundSchema),
   target: types.optional(z.array(CreateProjectEnv1Target$inboundSchema)),
   gitBranch: z.nullable(types.string()).optional(),
   comment: types.optional(types.string()),
@@ -932,7 +932,7 @@ export const CreateProjectEnv12$inboundSchema: z.ZodType<
 export type CreateProjectEnv12$Outbound = {
   key: string;
   value: string;
-  type: string;
+  type?: string | undefined;
   target?: Array<string> | undefined;
   gitBranch?: string | null | undefined;
   comment?: string | undefined;
@@ -947,7 +947,7 @@ export const CreateProjectEnv12$outboundSchema: z.ZodType<
 > = z.object({
   key: z.string(),
   value: z.string(),
-  type: CreateProjectEnv1Type$outboundSchema,
+  type: CreateProjectEnv1Type$outboundSchema.optional(),
   target: z.array(CreateProjectEnv1Target$outboundSchema).optional(),
   gitBranch: z.nullable(z.string()).optional(),
   comment: z.string().optional(),
@@ -993,7 +993,7 @@ export const CreateProjectEnv11$inboundSchema: z.ZodType<
 > = z.object({
   key: types.string(),
   value: types.string(),
-  type: OneType$inboundSchema,
+  type: types.optional(OneType$inboundSchema),
   target: z.array(OneTarget$inboundSchema),
   gitBranch: z.nullable(types.string()).optional(),
   comment: types.optional(types.string()),
@@ -1003,7 +1003,7 @@ export const CreateProjectEnv11$inboundSchema: z.ZodType<
 export type CreateProjectEnv11$Outbound = {
   key: string;
   value: string;
-  type: string;
+  type?: string | undefined;
   target: Array<string>;
   gitBranch?: string | null | undefined;
   comment?: string | undefined;
@@ -1018,7 +1018,7 @@ export const CreateProjectEnv11$outboundSchema: z.ZodType<
 > = z.object({
   key: z.string(),
   value: z.string(),
-  type: OneType$outboundSchema,
+  type: OneType$outboundSchema.optional(),
   target: z.array(OneTarget$outboundSchema),
   gitBranch: z.nullable(z.string()).optional(),
   comment: z.string().optional(),


### PR DESCRIPTION
Make createProjectEnv accept omitted type by updating request model typing and schema validation, then default missing type to sensitive at request execution time. This keeps explicit plain values for development and adds regression coverage for both omitted type and explicit plain-development behavior.

Similar to https://github.com/vercel/vercel/pull/16041