### PR TITLE
Use TF_SPEAKEASY_API_KEY secret managed by vercel/infra

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -32,4 +32,4 @@ jobs:
     secrets:
       github_access_token: ${{ secrets.PR_CREATION_PAT }}
       npm_token: ${{ secrets.NPM_TOKEN_ELEVATED }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      speakeasy_api_key: ${{ secrets.TF_SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -21,4 +21,4 @@ jobs:
     secrets:
       github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN_ELEVATED }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      speakeasy_api_key: ${{ secrets.TF_SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk_test.yaml
+++ b/.github/workflows/sdk_test.yaml
@@ -25,4 +25,4 @@ jobs:
         NODE_OPTIONS=--max-old-space-size=6144
     secrets:
       github_access_token: ${{ secrets.PR_CREATION_PAT }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+      speakeasy_api_key: ${{ secrets.TF_SPEAKEASY_API_KEY }}


### PR DESCRIPTION
## Summary

- Switches the Speakeasy API key reference in the SDK workflows from `SPEAKEASY_API_KEY` to `TF_SPEAKEASY_API_KEY`
- The new secret is provisioned on this repo via Terraform (vercel/infra#25566, vercel/infra#25562) — value lives in Terraform Cloud and rotates through that pipeline instead of being set manually

Touches `sdk_generation.yaml`, `sdk_publish.yaml`, `sdk_test.yaml`.

## Test plan

- [ ] Confirm `TF_SPEAKEASY_API_KEY` is present at https://github.com/vercel/sdk/settings/secrets/actions
- [ ] Trigger (or wait for) a run of each affected workflow and confirm Speakeasy auth succeeds
- [ ] Once confirmed, the old `SPEAKEASY_API_KEY` secret can be deleted from the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)