### PR TITLE
chore: switch Speakeasy workflows from PR_CREATION_PAT to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto_merge_speakeasy.yaml
+++ b/.github/workflows/auto_merge_speakeasy.yaml
@@ -22,4 +22,4 @@ jobs:
             gh pr merge "$PR_NUMBER" --auto --squash --repo "${{ github.repository }}"
           fi
         env:
-          GH_TOKEN: ${{ secrets.PR_CREATION_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -30,6 +30,6 @@ jobs:
       environment: |
         NODE_OPTIONS="--max-old-space-size=12288"
     secrets:
-      github_access_token: ${{ secrets.PR_CREATION_PAT }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_TOKEN_ELEVATED }}
       speakeasy_api_key: ${{ secrets.TF_SPEAKEASY_API_KEY }}

--- a/.github/workflows/sdk_test.yaml
+++ b/.github/workflows/sdk_test.yaml
@@ -24,5 +24,5 @@ jobs:
       env_vars: |
         NODE_OPTIONS=--max-old-space-size=6144
     secrets:
-      github_access_token: ${{ secrets.PR_CREATION_PAT }}
+      github_access_token: ${{ secrets.GITHUB_TOKEN }}
       speakeasy_api_key: ${{ secrets.TF_SPEAKEASY_API_KEY }}


### PR DESCRIPTION
## Summary

- Replaces `secrets.PR_CREATION_PAT` with `secrets.GITHUB_TOKEN` in `sdk_generation.yaml`, `sdk_test.yaml`, and `auto_merge_speakeasy.yaml`
- PATs are not currently available, so using the built-in `GITHUB_TOKEN` as a temporary measure

## Known limitations

- `sdk_test.yaml` — `GITHUB_TOKEN` may have restricted scope inside Speakeasy's Docker container, potentially causing clone failures
- `auto_merge_speakeasy.yaml` — merges authored by `GITHUB_TOKEN` do not trigger downstream workflows (e.g. `sdk_publish.yaml` may be silently skipped after auto-merge)

These were the original reasons PAT was introduced (#261, #262, #263). Can be reverted once a PAT is available again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)