### PR TITLE
ci: enable signed commits in Speakeasy generation workflow

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -26,6 +26,7 @@ jobs:
       set_version: ${{ github.event.inputs.set_version }}
       speakeasy_version: latest
       enable_sdk_changelog: true
+      signed_commits: true
       target: vercel
       environment: |
         NODE_OPTIONS="--max-old-space-size=12288"


### PR DESCRIPTION
## Why

The `vercel/sdk` repo has a \"Require signed commits\" branch ruleset. The Speakeasy generation workflow was pushing unsigned commits (`signed_commits: false` by default), causing pushes to be rejected:

```
remote: error: GH013: Repository rule violations found for refs/heads/...
remote: - Commits must have verified signatures.
```

## Fix

Pass `signed_commits: true` to `workflow-executor.yaml@v15`. When enabled, Speakeasy uses the GitHub GraphQL `createCommitOnBranch` mutation instead of `git commit` + `git push` — commits are automatically signed with GitHub's web-flow key and satisfy the ruleset. No GPG keys or secrets needed.

## Test plan
- [ ] Trigger a manual generation run and confirm it completes without the signed-commits rejection