### PR TITLE
ci: fix 'targetting' typo in Speakeasy-generated FUNCTIONS.md

### DIFF
--- a/.github/workflows/fix-speakeasy-docs.yaml
+++ b/.github/workflows/fix-speakeasy-docs.yaml
@@ -1,0 +1,25 @@
+name: Fix Speakeasy-generated docs
+
+on:
+  push:
+    branches:
+      - speakeasy-sdk-regen-*
+
+jobs:
+  fix-generated-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Fix typos in Speakeasy-generated docs
+        run: sed -i 's/targetting/targeting/g' FUNCTIONS.md
+      - name: Commit if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add FUNCTIONS.md
+          git diff --staged --quiet || git commit -m "fix: correct targetting typo in generated FUNCTIONS.md"
+          git push

--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -1,11 +1,11 @@
 # Standalone Functions
 
 > [!NOTE]
-> This section is useful if you are using a bundler and targetting browsers and
+> This section is useful if you are using a bundler and targeting browsers and
 > runtimes where the size of an application affects performance and load times. 
 
 Every method in this SDK is also available as a standalone function. This
-alternative API is suitable when targetting the browser or serverless runtimes
+alternative API is suitable when targeting the browser or serverless runtimes
 and using a bundler to build your application since all unused functionality
 will be tree-shaken away. This includes code for unused methods, Zod schemas,
 encoding helpers and response handlers. The result is dramatically smaller


### PR DESCRIPTION
## Summary

- Fixes the immediate typo: `targetting` → `targeting` (2 occurrences) in the current `FUNCTIONS.md`
- Adds `.github/workflows/fix-speakeasy-docs.yaml` — triggers on every `speakeasy-sdk-regen-*` push and re-applies the fix as a follow-up commit, so it survives future SDK regenerations

## Why a workflow

`FUNCTIONS.md` is fully generated by Speakeasy's internal TypeScript SDK template, which isn't directly customisable. Without the workflow, the fix would be overwritten on the next SDK regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)