### PR TITLE
chore: re-enable mock server testing

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -28,8 +28,8 @@ generation:
   versioningStrategy: automatic
   persistentEdits: {}
   tests:
-    generateTests: false
-    generateNewTests: false
+    generateTests: true
+    generateNewTests: true
     skipResponseBodyAssertions: true
 typescript:
   version: 1.21.6

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -22,4 +22,4 @@ targets:
                 location: registry.speakeasyapi.dev/vercel/vercel-docs/vercel-oas-typescript-code-samples
             blocking: false
         testing:
-            enabled: false
+            enabled: true


### PR DESCRIPTION
## Summary

Re-enables mock server testing in Speakeasy. The original reason for disabling (#288, and `testing.enabled` going back to #31) is fixed upstream in [Speakeasy v1.763.1](https://github.com/speakeasy-api/speakeasy/releases/tag/v1.763.1).

- `.speakeasy/gen.yaml`: `generateTests` and `generateNewTests` → `true`
- `.speakeasy/workflow.yaml`: `testing.enabled` → `true`

## Test plan

- [ ] Next Speakeasy generation run produces mock tests without canceling
- [ ] `sdk_test.yaml` GH Action passes against generated tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)