### PR TITLE
security: add pnpm minimumReleaseAge to prevent supply chain attacks

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 2880 # 2 days. Company-wide standard


### PR DESCRIPTION
## Summary

- Adds `minimumReleaseAge: 2880` (2 days) to `pnpm-workspace.yaml` per company-wide security standard
- Prevents supply chain attacks by requiring packages to be published for at least 2 days before installation

Per [#announcements-engineering](https://vercel.slack.com/archives/C04EP0UV4KE/p1779299982505439)

🤖 Generated with [Claude Code](https://claude.com/claude-code)