### PR TITLE
fix: disable MCP server generation

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -47,7 +47,7 @@ typescript:
   constFieldsAlwaysOptional: false
   defaultErrorName: SDKError
   enableCustomCodeRegions: false
-  enableMCPServer: true
+  enableMCPServer: false
   enableReactQuery: false
   enumFormat: union
   exportZodModelNamespace: false


### PR DESCRIPTION
## Summary

- Sets `enableMCPServer: false` in `.speakeasy/gen.yaml` to disable MCP server generation

## Test plan

- [ ] Trigger generation workflow and confirm MCP server files are not produced