### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@vercel/sdk",
   "version": "1.27.0",
   "author": "Speakeasy",
+  "license": "Apache-2.0",
   "type": "module",
   "main": "./esm/index.js",
   "exports": {


### PR DESCRIPTION
## Summary

- add Apache-2.0 license metadata to the package manifest
- align the published npm metadata with the repository license

## Verification

- `npm view @vercel/sdk@latest name version license repository homepage bugs --json`
- `node -e "const p=require('./package.json'); if (p.license !== 'Apache-2.0') throw new Error('license mismatch'); console.log(p.name, p.version, p.license)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`
