### PR TITLE
fix: persist Apache-2.0 license in package.json via additionalPackageJSON

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -38,7 +38,8 @@ typescript:
     dependencies: {}
     devDependencies: {}
     peerDependencies: {}
-  additionalPackageJSON: {}
+  additionalPackageJSON:
+    license: Apache-2.0
   additionalScripts: {}
   alwaysIncludeInboundAndOutbound: false
   author: Speakeasy


### PR DESCRIPTION
## Summary

- Adds `license: Apache-2.0` to `additionalPackageJSON` in `.speakeasy/gen.yaml`

## Why

PR #311 adds the `license` field directly to `package.json`, but Speakeasy rewrites `package.json` on every generation run. Without this change, the license field would be overwritten and lost after the next generation.

Setting it in `additionalPackageJSON` ensures Speakeasy includes it in every generated `package.json`, making it permanent.

## Verification

After the next generation run, confirm:
```
node -e "const p=require('./package.json'); console.log(p.license)"
# → Apache-2.0
```