### PR TITLE
[MKT-3999] Preserve Connex SDK environment exports

### DIFF
--- a/overlay-title.yaml
+++ b/overlay-title.yaml
@@ -2,7 +2,7 @@ overlay: 1.0.0
 x-speakeasy-jsonpath: rfc9535
 info:
   title: Update spec title to "Vercel SDK"
-  version: 0.0.2
+  version: 0.0.3
 actions:
   # Update info
   - target: $.info
@@ -25,3 +25,137 @@ actions:
   - target: $.paths['/v1/projects/{projectIdOrName}/feature-flags/segments/{segmentIdOrSlug}'].patch.responses['200'].content['application/json'].schema
     update:
       $ref: '#/components/schemas/Segment'
+  # Restore path and account selectors omitted from four legacy operations in
+  # the published OpenAPI document. Speakeasy requires every templated path
+  # parameter to be declared before it can generate any SDK target.
+  - target: $.paths['/domains/{domain}/records'].put.parameters
+    update:
+      - name: domain
+        in: path
+        required: true
+        schema:
+          type: string
+          example: example.com
+      - name: teamId
+        in: query
+        description: The Team identifier to perform the request on behalf of.
+        schema:
+          type: string
+          example: team_1a2b3c4d5e6f7g8h9i0j1k2l
+      - name: slug
+        in: query
+        description: The Team slug to perform the request on behalf of.
+        schema:
+          type: string
+          example: my-team-url-slug
+  - target: $.paths['/domains/records/{recordId}'].get.parameters
+    update:
+      - name: recordId
+        in: path
+        required: true
+        description: The id of the DNS record
+        schema:
+          type: string
+          description: The id of the DNS record
+          example: rec_2qn7pzrx89yxy34vezpd31y9
+      - name: teamId
+        in: query
+        description: The Team identifier to perform the request on behalf of.
+        schema:
+          type: string
+          example: team_1a2b3c4d5e6f7g8h9i0j1k2l
+      - name: slug
+        in: query
+        description: The Team slug to perform the request on behalf of.
+        schema:
+          type: string
+          example: my-team-url-slug
+  - target: $.paths['/v1/security/firewall/config/{configVersion}'].delete.parameters
+    update:
+      - name: projectId
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: teamId
+        in: query
+        description: The Team identifier to perform the request on behalf of.
+        schema:
+          type: string
+          example: team_1a2b3c4d5e6f7g8h9i0j1k2l
+      - name: slug
+        in: query
+        description: The Team slug to perform the request on behalf of.
+        schema:
+          type: string
+          example: my-team-url-slug
+      - name: configVersion
+        in: path
+        required: true
+        description: The deployed configVersion for the firewall configuration
+        schema:
+          type: string
+  - target: $.paths['/v1/security/firewall/config/{configVersion}/activate'].post.parameters
+    update:
+      - name: projectId
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: teamId
+        in: query
+        description: The Team identifier to perform the request on behalf of.
+        schema:
+          type: string
+          example: team_1a2b3c4d5e6f7g8h9i0j1k2l
+      - name: slug
+        in: query
+        description: The Team slug to perform the request on behalf of.
+        schema:
+          type: string
+          example: my-team-url-slug
+      - name: configVersion
+        in: path
+        required: true
+        description: The deployed configVersion for the firewall configuration
+        schema:
+          type: string
+  # Preserve the existing public TypeScript enum value exports while widening
+  # Connex environment fields to also carry stable custom environment IDs.
+  # Without these explicit parent/child names, Speakeasy gives the union the
+  # old public name and renames the runtime enum value to a generated `*2`
+  # symbol, which is a breaking change for a patch SDK release.
+  - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.createdBy.oneOf[1].properties.environment
+    update:
+      x-speakeasy-name-override: created_by_environment_target
+  - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.createdBy.oneOf[1].properties.environment.oneOf[1]
+    update:
+      x-speakeasy-name-override: created_by_environment
+  - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.updatedBy.oneOf[1].properties.environment
+    update:
+      x-speakeasy-name-override: updated_by_environment_target
+  - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.updatedBy.oneOf[1].properties.environment.oneOf[1]
+    update:
+      x-speakeasy-name-override: updated_by_environment
+  - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.includes.properties.projects.properties.items.items.properties.environments.items
+    update:
+      x-speakeasy-name-override: create_connector_environment_target
+  - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.includes.properties.projects.properties.items.items.properties.environments.items.oneOf[1]
+    update:
+      x-speakeasy-name-override: create_connector_environments
+  - target: $.paths['/v1/connect/token/{connector}/import'].post.requestBody.content['application/json'].schema.properties.tokens.items.properties.environment
+    update:
+      x-speakeasy-name-override: import_connector_tokens_environment_target
+  - target: $.paths['/v1/connect/token/{connector}/import'].post.requestBody.content['application/json'].schema.properties.tokens.items.properties.environment.anyOf[0]
+    update:
+      enum:
+        - development
+        - preview
+        - production
+      x-speakeasy-name-override: import_connector_tokens_environment
+  - target: $.paths['/v1/connect/token/{connector}/import'].post.responses['200'].content['application/json'].schema.properties.tokens.items.properties.environment
+    update:
+      x-speakeasy-name-override: import_connector_tokens_connect_environment_target
+  - target: $.paths['/v1/connect/token/{connector}/import'].post.responses['200'].content['application/json'].schema.properties.tokens.items.properties.environment.oneOf[1]
+    update:
+      x-speakeasy-name-override: import_connector_tokens_connect_environment

--- a/overlay-title.yaml
+++ b/overlay-title.yaml
@@ -25,127 +25,30 @@ actions:
   - target: $.paths['/v1/projects/{projectIdOrName}/feature-flags/segments/{segmentIdOrSlug}'].patch.responses['200'].content['application/json'].schema
     update:
       $ref: '#/components/schemas/Segment'
-  # Restore path and account selectors omitted from four legacy operations in
-  # the published OpenAPI document. Speakeasy requires every templated path
-  # parameter to be declared before it can generate any SDK target.
-  - target: $.paths['/domains/{domain}/records'].put.parameters
-    update:
-      - name: domain
-        in: path
-        required: true
-        schema:
-          type: string
-          example: example.com
-      - name: teamId
-        in: query
-        description: The Team identifier to perform the request on behalf of.
-        schema:
-          type: string
-          example: team_1a2b3c4d5e6f7g8h9i0j1k2l
-      - name: slug
-        in: query
-        description: The Team slug to perform the request on behalf of.
-        schema:
-          type: string
-          example: my-team-url-slug
-  - target: $.paths['/domains/records/{recordId}'].get.parameters
-    update:
-      - name: recordId
-        in: path
-        required: true
-        description: The id of the DNS record
-        schema:
-          type: string
-          description: The id of the DNS record
-          example: rec_2qn7pzrx89yxy34vezpd31y9
-      - name: teamId
-        in: query
-        description: The Team identifier to perform the request on behalf of.
-        schema:
-          type: string
-          example: team_1a2b3c4d5e6f7g8h9i0j1k2l
-      - name: slug
-        in: query
-        description: The Team slug to perform the request on behalf of.
-        schema:
-          type: string
-          example: my-team-url-slug
-  - target: $.paths['/v1/security/firewall/config/{configVersion}'].delete.parameters
-    update:
-      - name: projectId
-        in: query
-        required: true
-        schema:
-          type: string
-      - name: teamId
-        in: query
-        description: The Team identifier to perform the request on behalf of.
-        schema:
-          type: string
-          example: team_1a2b3c4d5e6f7g8h9i0j1k2l
-      - name: slug
-        in: query
-        description: The Team slug to perform the request on behalf of.
-        schema:
-          type: string
-          example: my-team-url-slug
-      - name: configVersion
-        in: path
-        required: true
-        description: The deployed configVersion for the firewall configuration
-        schema:
-          type: string
-  - target: $.paths['/v1/security/firewall/config/{configVersion}/activate'].post.parameters
-    update:
-      - name: projectId
-        in: query
-        required: true
-        schema:
-          type: string
-      - name: teamId
-        in: query
-        description: The Team identifier to perform the request on behalf of.
-        schema:
-          type: string
-          example: team_1a2b3c4d5e6f7g8h9i0j1k2l
-      - name: slug
-        in: query
-        description: The Team slug to perform the request on behalf of.
-        schema:
-          type: string
-          example: my-team-url-slug
-      - name: configVersion
-        in: path
-        required: true
-        description: The deployed configVersion for the firewall configuration
-        schema:
-          type: string
-  # Preserve the existing public TypeScript enum value exports while widening
-  # Connex environment fields to also carry stable custom environment IDs.
-  # Without these explicit parent/child names, Speakeasy gives the union the
-  # old public name and renames the runtime enum value to a generated `*2`
-  # symbol, which is a breaking change for a patch SDK release.
+  # Preserve existing public enum exports while naming the widened unions
+  # independently. Titles name the inline union types without renaming their
+  # containing `environment` properties.
   - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.createdBy.oneOf[1].properties.environment
     update:
-      x-speakeasy-name-override: created_by_environment_target
+      title: CreatedByEnvironmentTarget
   - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.createdBy.oneOf[1].properties.environment.oneOf[1]
     update:
       x-speakeasy-name-override: created_by_environment
   - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.updatedBy.oneOf[1].properties.environment
     update:
-      x-speakeasy-name-override: updated_by_environment_target
+      title: UpdatedByEnvironmentTarget
   - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.updatedBy.oneOf[1].properties.environment.oneOf[1]
     update:
       x-speakeasy-name-override: updated_by_environment
   - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.includes.properties.projects.properties.items.items.properties.environments.items
     update:
-      x-speakeasy-name-override: create_connector_environment_target
+      title: CreateConnectorEnvironmentTarget
   - target: $.paths['/v1/connect/connectors'].post.responses['201'].content['application/json'].schema.properties.includes.properties.projects.properties.items.items.properties.environments.items.oneOf[1]
     update:
       x-speakeasy-name-override: create_connector_environments
   - target: $.paths['/v1/connect/token/{connector}/import'].post.requestBody.content['application/json'].schema.properties.tokens.items.properties.environment
     update:
-      x-speakeasy-name-override: import_connector_tokens_environment_target
+      title: ImportConnectorTokensEnvironmentTarget
   - target: $.paths['/v1/connect/token/{connector}/import'].post.requestBody.content['application/json'].schema.properties.tokens.items.properties.environment.anyOf[0]
     update:
       enum:
@@ -155,7 +58,7 @@ actions:
       x-speakeasy-name-override: import_connector_tokens_environment
   - target: $.paths['/v1/connect/token/{connector}/import'].post.responses['200'].content['application/json'].schema.properties.tokens.items.properties.environment
     update:
-      x-speakeasy-name-override: import_connector_tokens_connect_environment_target
+      title: ImportConnectorTokensConnectEnvironmentTarget
   - target: $.paths['/v1/connect/token/{connector}/import'].post.responses['200'].content['application/json'].schema.properties.tokens.items.properties.environment.oneOf[1]
     update:
       x-speakeasy-name-override: import_connector_tokens_connect_environment


### PR DESCRIPTION
Related: [MKT-3999](https://linear.app/vercel/issue/MKT-3999)

## Summary

- preserve the five published Connex built-in environment runtime exports
- add separately named, string-capable types for stable custom `env_*` IDs
- keep the public `environment` and `environments` property names unchanged

## Evidence

- source diff is one generator-overlay file: 39 additions and 2 deletions
- Speakeasy generation from this PR head produced commit [`bf8e993d`](https://github.com/vercel/sdk/commit/bf8e993d128fffe348d176889e4e8710e6489566)
- generated output preserves `CreatedByEnvironment`, `UpdatedByEnvironment`, `CreateConnectorEnvironments`, `ImportConnectorTokensEnvironment`, and `ImportConnectorTokensConnectEnvironment`
- generated output adds five corresponding `*Target` aliases and no replacement `*2` enum names for these fields
- generated artifact passes `npm ci`, `npm run build`, `npm run lint`, `npm pack --dry-run`, and a consumer compile/runtime smoke covering all five exports and aliases

The generic [Test SDK check](https://github.com/vercel/sdk/actions/runs/30118840686/job/89566123024) fails because the shared workflow invokes `npm run test`, but this repository defines no `test` script. The generated proof also contains accumulated unrelated OpenAPI drift, so it remains separate from this focused source PR and is not itself a release candidate.