### PR TITLE
ci: close superseded regen PRs before generation

### DIFF
--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -17,7 +17,59 @@ permissions:
   schedule:
     - cron: 0 0 * * *
 jobs:
+  # The generation action reuses the branch of any open regen PR, then aborts with
+  # "external changes detected" because signed_commits makes it create commits through
+  # the GitHub API as github-actions[bot] — a name missing from its own automation
+  # allow-list, so it misreads its own commit as a human push. Signed commits are
+  # required on every ref by org ruleset, so closing the stale PR first is the fix:
+  # with no open regen PR the action starts a fresh speakeasy-sdk-regen-<ts> branch.
+  # Nothing is lost by closing one — every run resets to main and regenerates against
+  # the live OpenAPI document, so the next PR supersedes the old one completely.
+  sweep-superseded-regen-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Close superseded regen PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Only bot-authored PRs on speakeasy-sdk-regen-* branches are eligible.
+          # Approved PRs are left alone (they merge within minutes of approval), as is
+          # anything labelled sweep-hold.
+          stale=$(gh pr list --state open --limit 100 \
+            --json number,headRefName,reviewDecision,labels,author \
+            --jq '[.[]
+                   | select(.headRefName | startswith("speakeasy-sdk-regen-"))
+                   | select(.author.is_bot)
+                   | select(.reviewDecision != "APPROVED")
+                   | select([.labels[].name] | index("sweep-hold") | not)]')
+
+          if [ "$(jq 'length' <<<"$stale")" -eq 0 ]; then
+            echo "No superseded regen PR to close." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          jq -r '.[] | "\(.number)\t\(.headRefName)"' <<<"$stale" |
+            while IFS="$(printf '\t')" read -r num branch; do
+              echo "Closing #${num} (${branch})"
+              gh pr close "$num" --comment \
+                "Closed by the \`Generate\` workflow so this run can start from a fresh branch. A replacement PR generated against the current OpenAPI document will open shortly, containing everything this one had. To keep a regen PR open across runs, add the \`sweep-hold\` label."
+              # Best-effort: the action ignores branches with no open PR, so a failed
+              # delete only leaves clutter behind.
+              gh api -X DELETE "repos/${GH_REPO}/git/refs/heads/${branch}" >/dev/null 2>&1 ||
+                echo "  branch ${branch} not deleted (harmless)"
+              echo "- Closed #${num} (\`${branch}\`)" >> "$GITHUB_STEP_SUMMARY"
+            done
+
   generate:
+    needs: sweep-superseded-regen-pr
+    # Never let a sweep failure make things worse than the current behaviour.
+    if: ${{ !cancelled() }}
     uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
     with:
       force: ${{ github.event.inputs.force }}

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -57,13 +57,13 @@ jobs:
           jq -r '.[] | "\(.number)\t\(.headRefName)"' <<<"$stale" |
             while IFS="$(printf '\t')" read -r num branch; do
               echo "Closing #${num} (${branch})"
+              # The branch is deliberately kept. The action only reuses branches that
+              # have an open PR, so a dangling branch is invisible to it — and keeping it
+              # means this PR stays reopenable if the run now fails for an unrelated
+              # reason instead of producing the replacement.
               gh pr close "$num" --comment \
-                "Closed by the \`Generate\` workflow so this run can start from a fresh branch. A replacement PR generated against the current OpenAPI document will open shortly, containing everything this one had. To keep a regen PR open across runs, add the \`sweep-hold\` label."
-              # Best-effort: the action ignores branches with no open PR, so a failed
-              # delete only leaves clutter behind.
-              gh api -X DELETE "repos/${GH_REPO}/git/refs/heads/${branch}" >/dev/null 2>&1 ||
-                echo "  branch ${branch} not deleted (harmless)"
-              echo "- Closed #${num} (\`${branch}\`)" >> "$GITHUB_STEP_SUMMARY"
+                "Closed by the \`Generate\` workflow so this run can start from a fresh branch. A replacement PR generated against the current OpenAPI document will open shortly, containing everything this one had. If that run fails instead, reopen this PR — its branch is left in place for exactly that case. To keep a regen PR open across runs, add the \`sweep-hold\` label."
+              echo "- Closed #${num} (\`${branch}\`, branch kept so it can be reopened)" >> "$GITHUB_STEP_SUMMARY"
             done
 
   generate:


### PR DESCRIPTION
## Problem

The nightly `Generate` job fails more often than it succeeds: **66 of 92 scheduled runs** between May 1 and Jul 31. 40 of them died in about two minutes with the same error ([most recent](https://github.com/vercel/sdk/actions/runs/30502409698)):

```
INFO:  Found existing branch speakeasy-sdk-regen-1785284543
INFO:  Found 1 non-CI commits on branch speakeasy-sdk-regen-1785284543
##[error] external changes detected on branch ... The action cannot proceed
```

No external commit was ever pushed. That "non-CI commit" is the bot's own regen commit — `291297a1`, author `github-actions[bot]`, verified.

The cost is a silently stale SDK. An `api-observability` → `observability` tag rename in `vercel/api` reached the docs site while `@vercel/sdk` kept shipping `apiObservability` for two more days.

## Why this fixes it

The action skips its external-change guard only if the commit author is in `managedAutomationUsers` — `speakeasy-github[bot]`, `speakeasybot`, `speakeasy-bot` (`internal/git/git.go:49`) — or the message starts with `ci` (`internal/git/git.go:525`). This repo misses both:

- `signed_commits: true` sends the commit through `Git.CreateCommit` with no author set (`internal/git/git.go:682`), so GitHub attributes it to `github-actions[bot]`. The unsigned path uses `speakeasybot` and would pass (`internal/git/git.go:622`).
- `enable_sdk_changelog: true` replaces `ci: regenerated with OpenAPI Doc ...` with the changelog heading `## Typescript SDK Changes:` (`internal/git/git.go:609`), so the `ci` fallback misses too.

Neither knob is discretionary — the **Require signed branch commits** ruleset targets `~ALL` refs, so unsigned commits are rejected on the regen branch itself.

But the guard is only reachable when the action **reuses a branch**, and it only reuses one when an **open** regen PR exists (`internal/actions/runWorkflow.go:68`). With no open regen PR it creates a fresh `speakeasy-sdk-regen-<timestamp>` branch and never evaluates the guard (`internal/git/git.go:436`). That single condition explains the intermittency — correlation across scheduled runs is 13/13.

So this PR removes the precondition rather than the guard: a `sweep-superseded-regen-pr` job that `generate` depends on, closing any open PR that is bot-authored, on a `speakeasy-sdk-regen-*` branch, not `APPROVED`, and not labelled `sweep-hold`.

Nothing is lost by closing one — every run resets the branch to `main` and regenerates against the live OpenAPI document, so the next PR supersedes the previous one entirely.

Two deliberate choices:

- `generate` carries `if: ${{ !cancelled() }}`, so a sweep failure can never make things worse than today.
- Approved PRs are skipped rather than merged. Approval-to-merge across the last 12 regen PRs is **0.0h in all 12**, so an approved PR is already a merged PR.
- The branch is kept, not deleted. Closing the PR is enough to free it — the action only reuses branches attached to an open PR (`internal/git/git.go:220`), so a dangling branch is invisible to it. Keeping it makes the sweep recoverable: since half the runs that clear the guard still fail for unrelated reasons, a swept PR can be reopened instead of waiting for a later green run.

That last measurement also rules out the obvious alternative: auto-merge would close a gap that does not exist. The entire delay is opened-to-approved — median ~18h against a ~23.5h fuse, which is why the outcome looks random. #333 lost by 23 minutes. Nor can reviewer availability be tightened enough: CODEOWNERS is `* @vercel/docs-team` and **Require Code Review** demands one code-owner approval with `bypass_actors: []`.

**This is not sufficient on its own.** Nights reaching generation go from 52/92 to 92/92, but only **50% of runs that clear the guard succeed** (26 of 52), so expected green nights go from 26 to roughly 46. The remainder is out of scope here and not yet investigated: 11 compile failures, 7 `POST /git/trees` timeouts (422/502), 7 `speakeasy run` wrapper failures, 1 transient 503. The tree-upload class shares a root with the `UpdateRef` 500 that killed a manual run on Jul 30 — the signed-commit path makes thousands of individual API writes and ends on an unretried ref update, 8 failures over three months. Worth raising upstream alongside the allow-list bug.

## How this was tested

Replaying each of the 40 guard failures against the blocking PR's review state **at that run's start time**:

| | |
|---|---|
| Guard failures in window | 40 |
| Would have been unblocked | **40** |
| Would not have helped | 0 |
| Distinct PRs closed | 11 — 9 later merged by a human, 2 abandoned anyway |

The skip-if-approved carve-out never triggers: no blocking PR was already approved at run time, which follows from the 0.0h measurement.

No false positives. Across all 47 PRs in the window: zero non-bot PRs on a `speakeasy-sdk-regen-*` branch, and all 29 regen PRs are authored by `app/github-actions`. Human branches look like `tonypan/mkt-3999-...` and `fix/disable-testing`. Run against the live repo, the selector also declines to close this PR.

Selector behavior:

| PR shape | Action |
|---|---|
| bot, `speakeasy-sdk-regen-*`, `REVIEW_REQUIRED` | closed |
| bot, `speakeasy-sdk-regen-*`, `APPROVED` | skipped |
| bot, `speakeasy-sdk-regen-*`, `sweep-hold` label | skipped |
| human, any other branch | skipped |

The residual cost is the 9 PRs that were eventually merged: their successor would have been reviewed instead. Content-equivalent, but a review in progress can disappear — that is what `sweep-hold` is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

